### PR TITLE
Skip malformed event entries and only add thumbnails if present

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -462,20 +462,30 @@ func (c *DdpaiCamera) getEvents() (error, FileList) {
 
 	// Get Event files
 	for _, event := range c.eventList.Event {
+		// Skip malformed entries with no video file (e.g. corrupt/incomplete camera events)
+		if event.Bvideoname == "" {
+			log.Warn("Skipping malformed event entry with no video file, index: ", event.Index)
+			continue
+		}
 		date, err := c.fileNameToDate(event.Bvideoname)
 		if err != nil {
-			return err, list
+			// Skip entries where the filename can't be parsed instead of stopping everything
+			log.Warn("Skipping event with unparseable filename: ", event.Bvideoname, " error: ", err)
+			continue
 		}
 		list = append(list, File{
 			name: event.Bvideoname,
 			url:  c.camPath + "/" + event.Bvideoname,
 			date: date,
 		})
-		list = append(list, File{
-			name: event.Imgname,
-			url:  c.camPath + "/" + event.Imgname,
-			date: date,
-		})
+		// Only add thumbnail if it exists
+		if event.Imgname != "" {
+			list = append(list, File{
+				name: event.Imgname,
+				url:  c.camPath + "/" + event.Imgname,
+				date: date,
+			})
+		}
 	}
 	return nil, list
 }


### PR DESCRIPTION
This PR improves the robustness of event file processing by:

Skipping malformed event entries that have no video file (e.g., corrupt or incomplete camera events).
Logging a warning when such entries are encountered, including the event index.
Skipping events with unparseable filenames instead of stopping the entire process, with a warning log for each.
Only adding thumbnail images to the file list if the thumbnail actually exists.
These changes prevent the process from failing due to bad data and ensure only valid files are processed.

Motivation:
Previously, encountering a malformed or incomplete event entry would halt the entire event processing, potentially missing valid files. This update ensures the downloader is more resilient to data issues from the camera.

Testing:

Verified that events with missing or invalid video filenames are skipped and logged.
Confirmed that thumbnails are only added when present.